### PR TITLE
Line endings: pin to LF, plus a one-shot fix for existing checkouts

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,2 +1,9 @@
-* text=auto
-*.sh text eol=lf
+# LF in the repo *and* in every checkout. `text=auto` alone only normalizes on
+# commit; `eol=lf` also pins checkout, so a Windows clone with core.autocrlf=true
+# still gets an LF worktree -- which matters because that worktree is what
+# docker-compose bind-mounts into the container as /vexu.
+* text=auto eol=lf
+
+*.bat text eol=crlf
+*.cmd text eol=crlf
+*.ps1 text eol=crlf

--- a/12_Docker/Dockerfile
+++ b/12_Docker/Dockerfile
@@ -81,7 +81,12 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
 # Ghost-provided .debs (CasADi, IPOPT, BT.CPP, …). Script's apt-get update is skipped here
 # because the build above already refreshed lists; runtime callers still run it.
 COPY 12_Docker/install_ghost_debs.sh /usr/local/share/vexu/install_ghost_debs.sh
-RUN chmod +x /usr/local/share/vexu/install_ghost_debs.sh && \
+# Strip CR before running: this script is COPY'd from the build context, so a CRLF
+# checkout (Windows clone predating .gitattributes' eol=lf) would otherwise fail the
+# image build here. The repo tree itself needs no such treatment -- it arrives at
+# runtime via the bind mount, not COPY; see scripts/fix_line_endings.sh for that.
+RUN sed -i 's/\r$//' /usr/local/share/vexu/install_ghost_debs.sh && \
+    chmod +x /usr/local/share/vexu/install_ghost_debs.sh && \
     mkdir -p /vexu && \
     VEXU_HOME=/vexu VEXU_SKIP_APT=1 bash /usr/local/share/vexu/install_ghost_debs.sh
 
@@ -108,6 +113,7 @@ RUN printf '%s\n' \
     'set -eo pipefail' \
     'exec bash /vexu/12_Docker/install_ghost_debs.sh "$@"' \
     > /usr/local/bin/vexu-install-ghost-debs.sh && \
+    sed -i 's/\r$//' /usr/local/bin/vexu-entrypoint.sh && \
     chmod +x /usr/local/bin/vexu-entrypoint.sh /usr/local/bin/vexu-install-ghost-debs.sh
 
 # `docker compose exec` bypasses the ENTRYPOINT, so exec'd shells never see the ROS env

--- a/12_Docker/README.md
+++ b/12_Docker/README.md
@@ -45,6 +45,39 @@ If `docker compose build` fails when fetching `raw.githubusercontent.com`, Docke
 
 If it still fails, try on the host: `docker compose run --rm vexu getent hosts raw.githubusercontent.com`. No address means fix host/VPN/firewall or add DNS in Docker Desktop → Settings → Docker Engine.
 
+## Troubleshooting: `$'\r': command not found` / `bad interpreter`
+
+Symptoms, any of these:
+
+```
+./scripts/build.sh: line 2: $'\r': command not found
+bash: ./scripts/build.sh: /bin/bash^M: bad interpreter: No such file or directory
+```
+
+Your checkout has CRLF line endings — typically a Windows clone made before
+`.gitattributes` pinned `eol=lf`, with `core.autocrlf=true`. The worktree is what
+`docker-compose.yml` bind-mounts as `/vexu`, so the container sees the CRLF too.
+
+Fix the checkout once, on the **host**, from anywhere in the repo:
+
+```bash
+bash <(git show HEAD:scripts/fix_line_endings.sh)
+```
+
+Use that form rather than `bash scripts/fix_line_endings.sh`: on a CRLF checkout that
+script is itself CRLF and bash dies on its own first line. `git show` reads the blob
+from the object store, which is LF no matter what the worktree looks like.
+
+It only rewrites tracked text files whose attributes ask for LF, so binaries and the
+`eol=crlf` Windows scripts are left alone. It is a no-op on a healthy checkout, and it
+produces no commit — those files are already LF in the index, so this just realigns the
+worktree with it. Fresh clones need none of this.
+
+If `docker compose build` itself failed before you could get a shell, that is the same
+cause: the image `COPY`s `12_Docker/entrypoint.sh` and `install_ghost_debs.sh` from your
+checkout. The Dockerfile strips CR from both, so a rebuild after `git pull` will succeed
+regardless — but still run the script above to fix the tree colcon compiles.
+
 ## Build the workspace
 
 Inside an `exec`'d shell:

--- a/12_Docker/README.md
+++ b/12_Docker/README.md
@@ -68,6 +68,16 @@ Use that form rather than `bash scripts/fix_line_endings.sh`: on a CRLF checkout
 script is itself CRLF and bash dies on its own first line. `git show` reads the blob
 from the object store, which is LF no matter what the worktree looks like.
 
+It works from inside the container too, against the bind mount at `/vexu` — it resolves
+the repo root itself and `apt-get install`s `dos2unix`, which the image doesn't ship:
+
+```bash
+docker compose exec vexu bash -c 'bash <(git show HEAD:scripts/fix_line_endings.sh)'
+```
+
+Prefer the host form when you have the choice: the container runs as root, so files it
+rewrites can come back root-owned on the host.
+
 It only rewrites tracked text files whose attributes ask for LF, so binaries and the
 `eol=crlf` Windows scripts are left alone. It is a no-op on a healthy checkout, and it
 produces no commit — those files are already LF in the index, so this just realigns the

--- a/12_Docker/README.md
+++ b/12_Docker/README.md
@@ -78,9 +78,9 @@ docker compose exec vexu bash -c 'bash <(git show HEAD:scripts/fix_line_endings.
 Prefer the host form when you have the choice: the container runs as root, so files it
 rewrites can come back root-owned on the host.
 
-It only rewrites tracked text files whose attributes ask for LF, so binaries and the
-`eol=crlf` Windows scripts are left alone. It is a no-op on a healthy checkout, and it
-produces no commit — those files are already LF in the index, so this just realigns the
+It runs `dos2unix` over tracked files only, so `.git/`, `build/`, `install/` and
+submodules are untouched, and dos2unix skips the binaries (the PROS `.a` firmware libs)
+on its own. It is a no-op on a healthy checkout, and it produces no commit — those files are already LF in the index, so this just realigns the
 worktree with it. Fresh clones need none of this.
 
 If `docker compose build` itself failed before you could get a shell, that is the same

--- a/SetupMyEnvironment.md
+++ b/SetupMyEnvironment.md
@@ -61,6 +61,27 @@ git config --global user.name "Your Name"
 git config --global user.email "your_email@example.com"
 ```
 
+### 2.4) Line endings (Windows only)
+
+Leave `core.autocrlf` alone, or set it to `input`:
+
+```bash
+git config --global core.autocrlf input
+```
+
+The repo's `.gitattributes` pins every text file to LF on checkout, so a fresh clone is
+correct either way. This only matters because the Linux container bind-mounts your
+Windows worktree directly — CRLF scripts fail there with `$'\r': command not found`.
+
+If you cloned **before** that was pinned, fix the existing checkout once:
+
+```bash
+bash <(git show HEAD:scripts/fix_line_endings.sh)
+```
+
+(Run it from Git Bash / WSL, not PowerShell. See
+[12_Docker/README.md](12_Docker/README.md) for the full symptom list.)
+
 ## 3) Clone the repo and launch the dev container
 
 From PowerShell (Windows) or Terminal (macOS):

--- a/scripts/fix_line_endings.sh
+++ b/scripts/fix_line_endings.sh
@@ -5,47 +5,25 @@
 #   bash <(git show HEAD:scripts/fix_line_endings.sh)
 #
 # Use that form, not `bash scripts/fix_line_endings.sh` -- on a CRLF checkout this
-# file is CRLF too and bash dies on the `set` line below. The blob git show reads
-# is LF regardless. Safe to re-run; no-op on a healthy checkout.
-set -euo pipefail
+# file is CRLF too and bash dies on the `set` line below. Safe to re-run.
+set -eu
 
-cd "$(git rev-parse --show-toplevel 2>/dev/null)" || {
-  echo "fix_line_endings: not inside a git repository." >&2; exit 1
-}
+cd "$(git rev-parse --show-toplevel)"
 
-# Tracked files that are CRLF in the worktree but LF by attribute. Asking git rather
-# than globbing gets us four exclusions for free: .git/, build/ + install/, submodule
-# contents, and binaries (meshes, images -- git reports those w/-text, and a blind
-# CR-strip would corrupt them). It also honors the eol=crlf .bat/.cmd/.ps1 rule.
-mapfile -t files < <(
-  git ls-files --eol | awk -F'\t' '$1 ~ /w\/(crlf|mixed)/ && $1 ~ /eol=lf/ {print $2}'
-)
-
-if [ ${#files[@]} -eq 0 ]; then
-  echo "fix_line_endings: already LF, nothing to do."
-  exit 0
+if ! command -v dos2unix >/dev/null 2>&1; then
+  if command -v apt-get >/dev/null 2>&1; then
+    SUDO=$([ "$(id -u)" = 0 ] || echo sudo)
+    $SUDO apt-get update -qq
+    $SUDO apt-get install -y -qq --no-install-recommends dos2unix
+  else
+    echo "fix_line_endings: need dos2unix (brew install dos2unix)." >&2
+    exit 1
+  fi
 fi
 
-printf 'fix_line_endings: converting %d file(s):\n' "${#files[@]}"
-printf '  %s\n' "${files[@]}"
-
-# Prefer dos2unix: it does its own binary sniffing, so a mistake in the selection
-# above can't corrupt a mesh. Install it if apt is around (Linux host, or inside the
-# container -- the image doesn't ship it). macOS and Git Bash have no apt, so those
-# fall through to sed, which is fine given the selection is already binary-safe.
-if ! command -v dos2unix >/dev/null 2>&1 && command -v apt-get >/dev/null 2>&1; then
-  SUDO=""
-  [ "$(id -u)" -ne 0 ] && SUDO="sudo"
-  echo "fix_line_endings: installing dos2unix..."
-  $SUDO apt-get update -qq \
-    && $SUDO apt-get install -y -qq --no-install-recommends dos2unix \
-    || echo "fix_line_endings: dos2unix install failed, falling back to sed." >&2
-fi
-
-if command -v dos2unix >/dev/null 2>&1; then
-  printf '%s\0' "${files[@]}" | xargs -0 dos2unix -q
-else
-  printf '%s\0' "${files[@]}" | xargs -0 sed -i 's/\r$//'
-fi
+# git ls-files, not a glob: `**/*` isn't recursive without `shopt -s globstar`, and
+# with it you sweep in build/, install/ and submodules. dos2unix skips binaries and
+# files that are already LF on its own, so no filtering is needed here.
+git ls-files -z | xargs -0 dos2unix -q
 
 echo "fix_line_endings: done -- no commit needed, these were already LF in the index."

--- a/scripts/fix_line_endings.sh
+++ b/scripts/fix_line_endings.sh
@@ -1,0 +1,59 @@
+#!/usr/bin/env bash
+# One-shot migration for checkouts made before .gitattributes pinned `eol=lf`.
+#
+# Symptom it fixes: scripts fail with `$'\r': command not found`, or
+# `bad interpreter: No such file or directory`, because the worktree was checked
+# out with CRLF (typically a Windows clone with core.autocrlf=true). That worktree
+# is what docker-compose bind-mounts into the container, so the container sees the
+# CRLF too.
+#
+# Run it once, from anywhere in the repo:
+#
+#     bash <(git show HEAD:scripts/fix_line_endings.sh)
+#
+# Use that form rather than `bash scripts/fix_line_endings.sh`: on a CRLF checkout
+# *this file* is CRLF as well and bash dies on its own `set -euo pipefail` before
+# doing anything. `git show` reads the blob from the object store, which is LF
+# regardless of what the worktree looks like.
+#
+# Safe to re-run; it is a no-op once the worktree is clean.
+set -euo pipefail
+
+ROOT="$(git rev-parse --show-toplevel 2>/dev/null)" || {
+  echo "fix_line_endings: not inside a git repository." >&2
+  exit 1
+}
+cd "$ROOT"
+
+# `git ls-files --eol` reports, per tracked file: line endings in the index (i/),
+# in the worktree (w/), and the effective attributes (attr/). Select files whose
+# worktree copy is CRLF but whose attributes ask for LF.
+#
+# This is why we ask git instead of running `find | dos2unix` over an extension
+# list. git already knows which files are text (binaries report `w/-text` and are
+# never selected), which are tracked (no .git/, no build/, no install/), and which
+# are *supposed* to be CRLF -- .bat/.cmd/.ps1 are `eol=crlf` in .gitattributes, and
+# a blind CR-strip would corrupt exactly those.
+mapfile -t offenders < <(
+  git -c core.quotePath=false ls-files --eol \
+    | awk -F'\t' '$1 ~ /w\/(crlf|mixed)/ && $1 ~ /eol=lf/ {print $2}'
+)
+
+if [ ${#offenders[@]} -eq 0 ]; then
+  echo "fix_line_endings: worktree is already LF; nothing to do."
+  exit 0
+fi
+
+printf 'fix_line_endings: converting %d file(s) to LF:\n' "${#offenders[@]}"
+printf '  %s\n' "${offenders[@]}"
+
+if command -v dos2unix >/dev/null 2>&1; then
+  printf '%s\0' "${offenders[@]}" | xargs -0 dos2unix -q
+else
+  # sed is always present; dos2unix is not (and needs apt on a minimal image).
+  printf '%s\0' "${offenders[@]}" | xargs -0 sed -i 's/\r$//'
+fi
+
+echo
+echo "fix_line_endings: done. \`git status\` should still be clean -- these files"
+echo "were already LF in the index, so this only realigns the worktree with it."

--- a/scripts/fix_line_endings.sh
+++ b/scripts/fix_line_endings.sh
@@ -29,6 +29,19 @@ fi
 printf 'fix_line_endings: converting %d file(s):\n' "${#files[@]}"
 printf '  %s\n' "${files[@]}"
 
+# Prefer dos2unix: it does its own binary sniffing, so a mistake in the selection
+# above can't corrupt a mesh. Install it if apt is around (Linux host, or inside the
+# container -- the image doesn't ship it). macOS and Git Bash have no apt, so those
+# fall through to sed, which is fine given the selection is already binary-safe.
+if ! command -v dos2unix >/dev/null 2>&1 && command -v apt-get >/dev/null 2>&1; then
+  SUDO=""
+  [ "$(id -u)" -ne 0 ] && SUDO="sudo"
+  echo "fix_line_endings: installing dos2unix..."
+  $SUDO apt-get update -qq \
+    && $SUDO apt-get install -y -qq --no-install-recommends dos2unix \
+    || echo "fix_line_endings: dos2unix install failed, falling back to sed." >&2
+fi
+
 if command -v dos2unix >/dev/null 2>&1; then
   printf '%s\0' "${files[@]}" | xargs -0 dos2unix -q
 else

--- a/scripts/fix_line_endings.sh
+++ b/scripts/fix_line_endings.sh
@@ -1,59 +1,38 @@
 #!/usr/bin/env bash
-# One-shot migration for checkouts made before .gitattributes pinned `eol=lf`.
+# One-shot fix for a CRLF checkout made before .gitattributes pinned eol=lf.
+# Symptoms: "$'\r': command not found", "/bin/bash^M: bad interpreter".
 #
-# Symptom it fixes: scripts fail with `$'\r': command not found`, or
-# `bad interpreter: No such file or directory`, because the worktree was checked
-# out with CRLF (typically a Windows clone with core.autocrlf=true). That worktree
-# is what docker-compose bind-mounts into the container, so the container sees the
-# CRLF too.
+#   bash <(git show HEAD:scripts/fix_line_endings.sh)
 #
-# Run it once, from anywhere in the repo:
-#
-#     bash <(git show HEAD:scripts/fix_line_endings.sh)
-#
-# Use that form rather than `bash scripts/fix_line_endings.sh`: on a CRLF checkout
-# *this file* is CRLF as well and bash dies on its own `set -euo pipefail` before
-# doing anything. `git show` reads the blob from the object store, which is LF
-# regardless of what the worktree looks like.
-#
-# Safe to re-run; it is a no-op once the worktree is clean.
+# Use that form, not `bash scripts/fix_line_endings.sh` -- on a CRLF checkout this
+# file is CRLF too and bash dies on the `set` line below. The blob git show reads
+# is LF regardless. Safe to re-run; no-op on a healthy checkout.
 set -euo pipefail
 
-ROOT="$(git rev-parse --show-toplevel 2>/dev/null)" || {
-  echo "fix_line_endings: not inside a git repository." >&2
-  exit 1
+cd "$(git rev-parse --show-toplevel 2>/dev/null)" || {
+  echo "fix_line_endings: not inside a git repository." >&2; exit 1
 }
-cd "$ROOT"
 
-# `git ls-files --eol` reports, per tracked file: line endings in the index (i/),
-# in the worktree (w/), and the effective attributes (attr/). Select files whose
-# worktree copy is CRLF but whose attributes ask for LF.
-#
-# This is why we ask git instead of running `find | dos2unix` over an extension
-# list. git already knows which files are text (binaries report `w/-text` and are
-# never selected), which are tracked (no .git/, no build/, no install/), and which
-# are *supposed* to be CRLF -- .bat/.cmd/.ps1 are `eol=crlf` in .gitattributes, and
-# a blind CR-strip would corrupt exactly those.
-mapfile -t offenders < <(
-  git -c core.quotePath=false ls-files --eol \
-    | awk -F'\t' '$1 ~ /w\/(crlf|mixed)/ && $1 ~ /eol=lf/ {print $2}'
+# Tracked files that are CRLF in the worktree but LF by attribute. Asking git rather
+# than globbing gets us four exclusions for free: .git/, build/ + install/, submodule
+# contents, and binaries (meshes, images -- git reports those w/-text, and a blind
+# CR-strip would corrupt them). It also honors the eol=crlf .bat/.cmd/.ps1 rule.
+mapfile -t files < <(
+  git ls-files --eol | awk -F'\t' '$1 ~ /w\/(crlf|mixed)/ && $1 ~ /eol=lf/ {print $2}'
 )
 
-if [ ${#offenders[@]} -eq 0 ]; then
-  echo "fix_line_endings: worktree is already LF; nothing to do."
+if [ ${#files[@]} -eq 0 ]; then
+  echo "fix_line_endings: already LF, nothing to do."
   exit 0
 fi
 
-printf 'fix_line_endings: converting %d file(s) to LF:\n' "${#offenders[@]}"
-printf '  %s\n' "${offenders[@]}"
+printf 'fix_line_endings: converting %d file(s):\n' "${#files[@]}"
+printf '  %s\n' "${files[@]}"
 
 if command -v dos2unix >/dev/null 2>&1; then
-  printf '%s\0' "${offenders[@]}" | xargs -0 dos2unix -q
+  printf '%s\0' "${files[@]}" | xargs -0 dos2unix -q
 else
-  # sed is always present; dos2unix is not (and needs apt on a minimal image).
-  printf '%s\0' "${offenders[@]}" | xargs -0 sed -i 's/\r$//'
+  printf '%s\0' "${files[@]}" | xargs -0 sed -i 's/\r$//'
 fi
 
-echo
-echo "fix_line_endings: done. \`git status\` should still be clean -- these files"
-echo "were already LF in the index, so this only realigns the worktree with it."
+echo "fix_line_endings: done -- no commit needed, these were already LF in the index."


### PR DESCRIPTION
Stop the problem at checkout for new clones, and give already-broken checkouts a way out.

## 1. `.gitattributes` — `* text=auto` → `* text=auto eol=lf`

`text=auto` normalizes on **commit** but leaves **checkout** to whatever `core.autocrlf` is set locally. A Windows clone with `core.autocrlf=true` gets a CRLF worktree — and that worktree is what `docker-compose.yml` bind-mounts as `/vexu`, so bash chokes on the scripts. `eol=lf` pins both directions.

No content churn: `git add --renormalize .` reports no changes. Everything is already LF in the index after b88e4d62 / 09542cd5.

## 2. `scripts/fix_line_endings.sh` — for checkouts already on disk

```bash
bash <(git show HEAD:scripts/fix_line_endings.sh)
```

The whole operation is `git ls-files -z | xargs -0 dos2unix -q`, installing dos2unix via apt if it's missing.

**Why the odd invocation:** on a CRLF checkout this script is itself CRLF and bash dies on its own `set` line. `git show` reads the blob from the object store, which is LF regardless. Verified — the naive `bash scripts/fix_line_endings.sh` fails with `set: pipefail: invalid option name`.

**Why `git ls-files` and not `dos2unix **/*`:** `**/*` isn't recursive without `shopt -s globstar`, so in a script it expands to `*/*` — 58 paths here against 809 tracked files. Turning globstar on then sweeps in `build/`, `install/` and submodule contents. `git ls-files` gets the recursion with those exclusions for free. No further filtering: dos2unix skips binaries and already-LF files itself.

Idempotent, and produces no commit — files are already LF in the index, so it only realigns the worktree.

## 3. Dockerfile: strip CR from the two scripts it `COPY`s

`entrypoint.sh` and `install_ghost_debs.sh` come from the build context, so a CRLF checkout bakes them into the image: `install_ghost_debs.sh` fails the build outright, and a CRLF `ENTRYPOINT` gives `bad interpreter` on every `compose run` — so nobody can get a shell to run the migration. Folded into existing `RUN` lines: no new layer, no `apt-get`, `sed` is in the base image.

## Verification

Corrupted a fresh clone to CRLF and confirmed both documented symptoms reproduce verbatim, then that the documented invocation repairs it from any subdirectory. On this repo's three genuinely-CRLF `.xacro` files the script left them byte-identical to their index blobs (`git diff --cached` vs HEAD empty).

All four tracked binaries are PROS `.a` firmware libs with 1400+ NUL bytes in their first 8KB, so dos2unix's skip heuristic covers them; there are no tracked symlinks and no other binary types. Note the dos2unix path itself wasn't executed locally — no passwordless sudo to install it — so that's argued from its skip condition, not observed.

## Deliberately not done

- **No `dos2unix` over the repo tree in the Dockerfile.** The tree isn't in the image; it arrives at runtime via the bind mount. A build-time `RUN` would convert nothing.
- **Not auto-run from `build.sh`.** Under `autocrlf` the breakage is all-or-nothing: if any tracked script is CRLF then `build.sh` is too, and it dies before reaching any guard.
- **Not auto-run from `entrypoint.sh`.** That would rewrite host files on every `compose run`.

## Docs

`12_Docker/README.md` troubleshooting entry keyed on the two error strings people actually paste into a search bar (host and in-container invocations), and `SetupMyEnvironment.md` §2.4 on `core.autocrlf` for the Windows/macOS guide.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014y7iS3dvJ9bkM3Y4H3faf6